### PR TITLE
Fix markdown and spelling issues

### DIFF
--- a/_posts/2016-03-08-development-basics.md
+++ b/_posts/2016-03-08-development-basics.md
@@ -18,7 +18,7 @@ All quattor git repositories are part of the [quattor organisation on GitHub][qu
 
 1. An account on [GitHub][github]
 2. [Join][join_quattor] the quattor organisation and `developer` team
- * In case there is a problem, contact the mailinglist as [admins can also add new members][join_team_gh]
+   * In case there is a problem, contact the mailing list as [admins can also add new members][join_team_gh]
 3. Join the [`quattor-devel` mailing list][quattor_devel_ml]
 
 [github]: https://github.com
@@ -40,36 +40,31 @@ TODO: add more
 
 1. Fork the repository you want to work on
 2. Clone the forked repository locally using the `ssh` URL
- * Your fork is known as `origin`
+   * Your fork is known as `origin`
 3. Add the `upstream` repository using the `https` URL
 4. Start with a new branch
- * Do not work in `master` branch
+   * Do not work in `master` branch
 5. Make modifications, add and commit them
- * Try to use meaningfull messages
-  * For the the `configuration-modules-core` (and other `configuration-modules`) repository, set the
-    component name in the commit message when working on more then one component in same branch.
+   * Try to use meaningful messages
+     * For the the `configuration-modules-core` (and other `configuration-modules`) repository, set the component name in the commit message when working on more then one component in same branch.
 6. Push your changes to your fork (i.e. to `origin`)
- * Do not push to `upstream`
-7. Run the unittests
- * Add new ones to cover your changes (or refine existing ones)
+   * Do not push to `upstream`
+7. Run the unit tests
+   * Add new ones to cover your changes (or refine existing ones)
 8. Open a pull request (PR)
- * Meaningful title; title will be part of the relase notes
-  * For `configuration-modules` repository: start the title with the component that is being modified
-   * When more then one component is modified, describe the general work in the title;
-     the commit messages should have the component names.
- * Set `milestone` (i.e. the release you want this merged in)
-  * Set a realistic milestone, e.g. if the PR is not urgent or not finished
-    or you have no time to follow up, you might want to pick a later milestone.
-9. The initial PR will trigger a [jenkins][quattor_jenkins] build of the unittests
- * The tests are run with the PR merged in current master
+   * Meaningful title; title will be part of the release notes
+     * For `configuration-modules` repository: start the title with the component that is being modified
+     * When more then one component is modified, describe the general work in the title; the commit messages should have the component names.
+   * Set `milestone` (i.e. the release you want this merged in)
+     * Set a realistic milestone, e.g. if the PR is not urgent or not finished or you have no time to follow up, you might want to pick a later milestone.
+9. The initial PR will trigger a [jenkins][quattor_jenkins] build of the unit tests
+   * The tests are run with the PR merged in current master
 10. The PR will be reviewed, and after the reviewer is satisfied, it will be merged in.
 11. Every 2 months, a release is made by the release manager that will contain your changes
- * Only for severe regressions / bugs, the release manager might consider an intermediate
-   release to address the specific issue.
- * To start using your new code, you can make your own `package` and upload it to your own repository
-  * Best to add a separate `testing` yum repository (no snapshots)
-   * This repository should be empty most of the time, but you can put your self-built packages there
-     until the new release is out that conatins your changes.
+    * Only for severe regressions / bugs, the release manager might consider an intermediate release to address the specific issue.
+    * To start using your new code, you can make your own `package` and upload it to your own repository
+      * Best to add a separate `testing` yum repository (no snapshots)
+        * This repository should be empty most of the time, but you can put your self-built packages there until the new release is out that contains your changes.
 
 [quattor_jenkins]: https://jenkins1.ugent.be/view/Quattor/
 
@@ -77,36 +72,34 @@ TODO: add more
 
 Quattor uses `maven` for its software project management.
 
-All source code and unittests are kept under the `src` subdir.
+All source code and unit tests are kept under the `src` subdirectory.
 
- * `src/main/perl` for perl modules
- * `src/main/pan` for pan templates like `schema.pan`
- * `src/test/perl` for the perl unitttests (and any other perl helper modules that might required)
- * `src/test/resources` for pan templates that are used with the unittests
- * metaconfig services are an exception
+* `src/main/perl` for perl modules
+* `src/main/pan` for pan templates like `schema.pan`
+* `src/test/perl` for the perl unit tests (and any other perl helper modules that might required)
+* `src/test/resources` for pan templates that are used with the unit tests
+* metaconfig services are an exception
 
-During testing, a `target` subdir is created by the maven tool (and removed with `mvn clean`).
+During testing, a `target` subdirectory is created by the maven tool (and removed with `mvn clean`).
 
-The process is steered via a `pom.xml` file, that is derived from a quattor maven atrifact.
+The process is steered via a `pom.xml` file, that is derived from a quattor maven artifact.
 
 These pom files require few changes, but typical ones are:
 
- * add developer / maintainer
- * set the project name (e.g. in case of a new component)
- * add custom plugins for specific projects
- * bump the version of the `build-profile` to the latest using `mvn update`
+* add developer / maintainer
+* set the project name (e.g. in case of a new component)
+* add custom plugins for specific projects
+* bump the version of the `build-profile` to the latest using `mvn update`
 
 ## maven commands
 
 Most common commands are
 
 0. `mvn clean` cleans any previous maven runs (in particular the `target` directory)
-1. `mvn test` runs the unittests
- * best to run `mvn clean test`
-2. `mvn package` Sometimes you will want to make a rpm or tarball to start
- using your code while waiting for the PR to be reviewed and merged. This command
- will create the rpm (and tarball).
- * `package` also runs the tests, and also here it is advised to use `mvn clean package`
+1. `mvn test` runs the unit tests
+   * best to run `mvn clean test`
+2. `mvn package` Sometimes you will want to make a rpm or tarball to start using your code while waiting for the PR to be reviewed and merged. This command will create the rpm (and tarball).
+   * `package` also runs the tests, and also here it is advised to use `mvn clean package`
 
 When newer build tools are available, use `mvn update` to bump the version in the `pom.xml`
 (do not edit by hand).

--- a/_posts/2016-03-09-development-unittests.md
+++ b/_posts/2016-03-09-development-unittests.md
@@ -9,21 +9,21 @@ category: documentation
 
 # Running the tests
 
-All quattor projects have unittests. These are run via the `mvn test` command, and run the perl
-unittests under the `src/test/perl` subdirectory.
+All quattor projects have unit tests. These are run via the `mvn test` command, and run the perl
+unit tests under the `src/test/perl` subdirectory.
 
-Maven runs the tests via `prove` (the commandline tool from `TAP::Harness`), and the required
+Maven runs the tests via `prove` (the command line tool from `TAP::Harness`), and the required
 include paths are already set, except for any dependencies.
 
 `prove` only runs files with a `.t` suffix; any other files are ignored. This allows you to create
-any helper modules for the unittests themself under the `src/test/perl` directory (`src/test/perl`
-is added to the perl `@INC` via the `prove` commandline).
+any helper modules for the unit tests under the `src/test/perl` directory (`src/test/perl`
+is added to the perl `@INC` via the `prove` command line).
 
 The tests run the modules that are preprocessed by `mvn` in the `target/lib/perl` directory.
 The preprocessing does e.g. the templating of the `${author}`. It also means that any perl messages
 that have a line number in them, are from the templated files (so there's some offset to take into account).
 
-If you want to run a single unittest, add `-Dunittest=name_of_test.t` to the `mvn` commandline.
+If you want to run a single unit test, add `-Dunittest=name_of_test.t` to the `mvn` command line.
 
 ## Logging
 
@@ -38,7 +38,7 @@ TODO: document / distribute [bash_functions][mvn_bash_functions]
 
 ## mvnprove.pl
 
-TODO: run the unittests without maven adn using `-d` for logging control and support more than one selected unittest
+TODO: run the unit tests without maven and using `-d` for logging control and support more than one selected unittest
 
 # Dependencies
 
@@ -47,26 +47,24 @@ repositories.
 
 Basic non-perl:
 
- * `maven`
- * `panc` (`>= 10.2`)
+* `maven`
+* `panc` (`>= 10.2`)
 
 Optional non-perl:
 
- * `rpm-build` (for building rpms)
+* `rpm-build` (for building rpms)
 
 Perl dependencies:
 
- * number of quattor tools (`LC`, `CAF`, `CCM`)
- * perl modules required for runtime
- * perl modules required for testing
+* number of quattor tools (`LC`, `CAF`, `CCM`)
+* perl modules required for runtime
+* perl modules required for testing
 
-The quattor test framework `Test::Quattor` is controlled through maven
-(this is the `build-profile` in the `pom.xml`).
+The quattor test framework `Test::Quattor` is controlled through maven (this is the `build-profile` in the `pom.xml`).
 
 TODO: add list from `build_all_repos`
 
-*Note:* If your development environment is managed by Quattor, you can use the [quattor-development][template_qt_dev]
-to add all required dependencies
+*Note:* If your development environment is managed by Quattor, you can use the [quattor-development][template_qt_dev] to add all required dependencies
 
 [template_qt_dev]: https://github.com/quattor/template-library-os/blob/sl6.x-x86_64/rpms/quattor-development.pan
 
@@ -75,19 +73,19 @@ to add all required dependencies
 The [`build_all_repos`][build_all_repos] script tries to build all rpms for most quattor repositories.
 Repositories that are not build include `panc` and the template repositories.
 
-One of it's features is that it resolves (or tries to) all dependencies (currenlty) using `yum`.
+One of it's features is that it resolves (or tries to) all dependencies (currently) using `yum`.
 (`sudo` rights are required for `yum` and `repoquery`; it is __NOT__ recommended to run this as root)
 Perl dependencies that can't be installed via yum, are installed from `CPAN` (using `cpanm`).
 
-As it runs all unittests, the result of running the script is an environment where you can start developing.
+As it runs all unit tests, the result of running the script is an environment where you can start developing.
 
 By default, `build_all_repos` installs everything in a `quattordev` subdirectory, and has subdirectories
 
- * `repos` all the quattor git repos, with the remote `upstream` set.
+* `repos` all the quattor git repos, with the remote `upstream` set.
   * you need to add your fork as the remote `origin`.
- * `install` contains the quattor repositories from unpacked tarballs and any dependencies installed via `CPAN`
- * `rpms` contains all build rpms
- * a number of logfiles with e.g. the installed dependencies
+* `install` contains the quattor repositories from unpacked tarballs and any dependencies installed via `CPAN`
+* `rpms` contains all build rpms
+* a number of log files with e.g. the installed dependencies
 
 Running the script takes a while to complete. Best run it in a `screen` session and redirect the output to a logfile.
 (Best to check the `sudo` command upfront, as it can prompt for passsword, and thus block the script).
@@ -104,14 +102,14 @@ TODO: use the `source $DEST/env.sh` to set initial PERL5LIB
 
 The basic test module
 
- * `ok($bool, "message");` tests if `$bool` is true
+* `ok($bool, "message");` tests if `$bool` is true
   * use `ok(! $bool, "message");` to test if `$bool` is false
- * `is($a, $value, "message")` tests if `$a` is `$value`
+* `is($a, $value, "message")` tests if `$a` is `$value`
   * for comparing hash and array, use `is_deeply` to compare references
-   * `is_deeply(\%hash, {expected => 'value'}, "message");`
-   * `is_deeply(\@array, [qw(value1 value2)], "message");`
- * `isa_ok($instance, "Instance::Class::Name", "message")`  tests if `$instance` is an instance of class `Instance::Class::Name`
- * `like("text", qr{regexp}, "message");` tests if `"text"` matches the compiled regular rexpression `qr{regexp}`
+    * `is_deeply(\%hash, {expected => 'value'}, "message");`
+    * `is_deeply(\@array, [qw(value1 value2)], "message");`
+* `isa_ok($instance, "Instance::Class::Name", "message")`  tests if `$instance` is an instance of class `Instance::Class::Name`
+* `like("text", qr{regexp}, "message");` tests if `"text"` matches the compiled regular expression `qr{regexp}`
   * complex texts can be tested with `Test::Quattor::RegexpTest` TODO add reference
 
 ## Test::MockModule
@@ -123,7 +121,7 @@ E.g. by defining
 ```perl
 my $mock = Test::MockModule->new('NCM::Component::mycomponent');
 $mock->mock('do_something', sub () {return [qw(1 2 3)]} );
-``
+```
 
 you have mocked the `do_something` method of the `mycomponent` component.
 
@@ -199,29 +197,30 @@ try to use unique profiles to avoid this buggy behaviour.
 
 ### CAF::Process
 
- * `set_command_status`, `set_desired_output`, `set_desired_err` mock the status, stdout and stderr of future `CAF::Process` call
+* `set_command_status`, `set_desired_output`, `set_desired_err` mock the status, stdout and stderr of future `CAF::Process` call
 
-```perl
-set_desired_output("/usr/bin/command", "expected output");
-```
+  ```perl
+  set_desired_output("/usr/bin/command", "expected output");
+  ```
 
- * `get_command` use to test if a  `CAF::Process` with exact commandline was called (and returns the `CAF::Process` instance).
+* `get_command` use to test if a  `CAF::Process` with exact command line was called (and returns the `CAF::Process` instance).
 
-```perl
-ok(get_command("/usr/bin/someexecutable -l -s"), "Command was called");
-```
-   or if you need to access the instance
+  ```perl
+  ok(get_command("/usr/bin/someexecutable -l -s"), "Command was called");
+  ```
 
-```perl
-my $procinstance = get_command("/usr/bin/someexecutable -l -s");
-```
+  or if you need to access the instance
 
- * `command_history_ok`, `command_history_reset` test ordered execution of `CAF::Process` instances
+  ```perl
+  my $procinstance = get_command("/usr/bin/someexecutable -l -s");
+  ```
 
-```perl
-command_history_reset();
-ok(command_history_ok(['pattern1','pattern2']), "message");
-```
+* `command_history_ok`, `command_history_reset` test ordered execution of `CAF::Process` instances
+
+  ```perl
+  command_history_reset();
+  ok(command_history_ok(['pattern1','pattern2']), "message");
+  ```
 
 * additional logging environment variables
   * `QUATTOR_TEST_LOG_CMD=1` log each command that is run via CAF::Process
@@ -230,23 +229,23 @@ ok(command_history_ok(['pattern1','pattern2']), "message");
 
 ### CAF::FileWriter (Editor,Reader)
 
- * `get_file` returns the instance that opened/modified a file
+* `get_file` returns the instance that opened/modified a file
 
-```perl
-my $fh = get_file("/some/path");
-```
+  ```perl
+  my $fh = get_file("/some/path");
+  ```
 
- * `set_file_contents` set the content a future `CAF::File*` instance will see
+* `set_file_contents` set the content a future `CAF::File*` instance will see
 
-```perl
-set_file_contents("/some/path", $text);
-```
+  ```perl
+  set_file_contents("/some/path", $text);
+  ```
 
- * `set_caf_file_close_diff` mock the `CAF::File*->close()` return behaviour to return a true value if the content changed.
+* `set_caf_file_close_diff` mock the `CAF::File*->close()` return behaviour to return a true value if the content changed.
    By default, this is false, and `close()` will return some garbage.
 
-```perl
-set_caf_file_close_diff(1);
-```
+  ```perl
+  set_caf_file_close_diff(1);
+  ```
 
-TODO: why is this not default true?
+  TODO: why is this not default true?


### PR DESCRIPTION
This should allow the document to flow correctly when rendered with kramdown.
It also should remove many typos, but unfortunately not the one in the branch name.
